### PR TITLE
fix(user): 修复用户作品分页空列表和游标停滞导致死循环

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ docs/
 # 工具配置（本地开发用）
 .claude/
 .serena/
+.workbuddy/
 
 # 一次性脚本
 generate_icons.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+本文件用于约束 AI（Codex 等）在本仓库的工作行为。
+
+## Git 提交规范
+
+### 提交信息格式
+
+- 使用 conventional commits 前缀（`fix:`、`feat:`、`chore:`、`refactor:`、`docs:`、`style:`、`test:`、`perf:`），**前缀后面的描述用中文**。
+- 示例：
+  - `fix(player): 修复评论回复更新时标志泄漏导致的不必要重渲染`
+  - `feat(ui): 新增下载进度全局同步`
+  - `chore: 升级依赖版本`
+
+### 提交信息正文
+
+- 正文可选，使用中文，解释「为什么」而非「做了什么」。
+- 不要添加 `Co-Authored-By: Codex` 或类似的 AI 署名行。
+- 不要添加 `🤖 Generated with Codex` 之类的标记。
+
+### 示例
+
+```
+fix(player): 修复评论回复更新时标志泄漏
+
+updateCommentById 复用单个 changed 标志遍历所有回复容器，导致任一
+回复匹配后，后续所有容器都被浅拷贝，即使内容未变也会触发不必要的
+重渲染。改为按 cid 独立判断，仅浅拷贝实际变更的容器。
+```
+
+## 构建产物
+
+- `src/web/react_dist/` 是 `npm run build` 生成的产物，**不要提交到 git**。
+- 修改前端后如需运行 Python 版本，本地执行 `cd frontend && npm run build` 重新生成即可。
+
+## 分支与推送
+
+- 默认在 `main` 分支工作，提交后直接 `git push`。
+- 不要使用 `--no-verify` 跳过 hook，不要 `--force` 推送到 main。

--- a/src/user/user_manager.py
+++ b/src/user/user_manager.py
@@ -266,6 +266,7 @@ class DouyinUserManager:
         has_more = True
         
         while has_more and len(videos) < limit:
+            previous_cursor = max_cursor
             remaining = max(limit - len(videos), 1)
             request_count = min(USER_POST_PAGE_SIZE, remaining) if on_batch is not None else min(18, remaining)
             params = {
@@ -292,14 +293,24 @@ class DouyinUserManager:
                 }
             
             batch = resp.get('aweme_list', [])
+            next_cursor = resp.get('max_cursor', 0)
+            next_has_more = resp.get('has_more', 0) == 1
+            if not batch:
+                if self.debug_mode:
+                    print(f"\033[93m[UserManager] 用户作品分页返回空列表，停止继续抓取: user={user_id}, cursor={previous_cursor}, next_cursor={next_cursor}, has_more={next_has_more}\033[0m")
+                break
             if on_batch and batch:
                 on_batch(batch)
                 # 让下载消费者有机会在下一页抓取前先处理已入队作品
                 await asyncio.sleep(0)
                 
             videos.extend(batch)
-            max_cursor = resp.get('max_cursor', 0)
-            has_more = resp.get('has_more', 0) == 1
+            max_cursor = next_cursor
+            has_more = next_has_more
+            if has_more and max_cursor == previous_cursor:
+                if self.debug_mode:
+                    print(f"\033[93m[UserManager] 用户作品分页游标未前进，停止继续抓取: user={user_id}, cursor={max_cursor}\033[0m")
+                break
             
         return videos[:limit]
 

--- a/tests/check_user_videos_pagination.py
+++ b/tests/check_user_videos_pagination.py
@@ -1,0 +1,71 @@
+import pytest
+
+from src.user.user_manager import DouyinUserManager
+
+
+class FakePostApi:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    async def common_request(self, uri, params, headers, skip_sign=False):
+        self.calls.append((uri, dict(params), dict(headers), skip_sign))
+        if not self.responses:
+            raise AssertionError("get_user_videos did not stop after an empty/stalled page")
+        return self.responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_get_user_videos_stops_on_empty_has_more_page():
+    api = FakePostApi(
+        [
+            (
+                {
+                    "aweme_list": [{"aweme_id": "1", "desc": "first"}],
+                    "max_cursor": 10,
+                    "has_more": 1,
+                },
+                True,
+            ),
+            (
+                {
+                    "aweme_list": [],
+                    "max_cursor": 10,
+                    "has_more": 1,
+                },
+                True,
+            ),
+        ]
+    )
+    manager = object.__new__(DouyinUserManager)
+    manager.api = api
+    manager.debug_mode = False
+
+    videos = await manager.get_user_videos("sec-user", limit=10000)
+
+    assert [video["aweme_id"] for video in videos] == ["1"]
+    assert len(api.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_user_videos_stops_when_cursor_does_not_advance():
+    api = FakePostApi(
+        [
+            (
+                {
+                    "aweme_list": [{"aweme_id": "1", "desc": "first"}],
+                    "max_cursor": 0,
+                    "has_more": 1,
+                },
+                True,
+            ),
+        ]
+    )
+    manager = object.__new__(DouyinUserManager)
+    manager.api = api
+    manager.debug_mode = False
+
+    videos = await manager.get_user_videos("sec-user", limit=10000)
+
+    assert [video["aweme_id"] for video in videos] == ["1"]
+    assert len(api.calls) == 1


### PR DESCRIPTION
抓取用户作品时，API 返回空列表或游标未前进时未做检查，可能导致死循环。新增空列表检测和游标前进检测，遇异常时安全中断并在 debug 模式下输出警告。